### PR TITLE
update dependencies to fix vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
   "dependencies": {
     "foundry-release-base": "~1.0.1",
     "shell-quote": "~1.6.1",
-    "shelljs": "~0.2.6"
+    "shelljs": "~0.8.5"
   },
   "devDependencies": {
     "chai": "~1.10.0",
-    "foundry": "~4.5.0",
+    "foundry": "~4.7.0",
     "foundry-release-git": "~2.0.0",
-    "foundry-release-npm": "~2.0.0",
-    "grunt": "~1.4.0",
-    "grunt-contrib-jshint": "~3.0.0",
+    "foundry-release-npm": "~2.1.0",
+    "grunt": "~1.5.2",
+    "grunt-contrib-jshint": "~3.2.0",
     "grunt-contrib-watch": "~1.1.0",
     "mocha": "~8.4.0",
     "sinon": "~1.17.7",


### PR DESCRIPTION
The purpose is mainly to fix CVE-2022-0144 in shelljs.